### PR TITLE
Add switch component

### DIFF
--- a/components/src/lib.rs
+++ b/components/src/lib.rs
@@ -15,6 +15,7 @@ pub mod checkbox;
 pub mod collapsible;
 pub mod input;
 pub mod label;
+pub mod switch;
 pub mod theme;
 
 pub fn script_mod(vm: &mut ScriptVm) {
@@ -32,4 +33,5 @@ pub fn script_mod(vm: &mut ScriptVm) {
     crate::collapsible::script_mod(vm);
     crate::input::script_mod(vm);
     crate::label::script_mod(vm);
+    crate::switch::script_mod(vm);
 }

--- a/components/src/switch.rs
+++ b/components/src/switch.rs
@@ -1,0 +1,326 @@
+use makepad_widgets::widget::WidgetActionData;
+use makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.ShadSwitchBase = #(ShadSwitch::register_widget(vm))
+
+    mod.widgets.ShadSwitch = set_type_default() do mod.widgets.ShadSwitchBase{
+        width: Fit
+        height: Fit
+        label: "Switch"
+        checked: false
+        grab_key_focus: true
+
+        draw_bg +: {
+            hover: instance(0.0)
+            focus: instance(0.0)
+            checked_val: instance(0.0)
+
+            color_border: uniform(shad_theme.color_outline_border)
+            color_border_hover: uniform(shad_theme.color_outline_border_hover)
+            color_primary: uniform(shad_theme.color_primary)
+            color_background: uniform(shad_theme.color_background)
+
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+                sdf.clear(vec4(0.0))
+
+                let sz = self.rect_size
+
+                let border_width = 1.0
+                let switch_width = sz.x
+                let switch_height = sz.y
+                let radius = switch_height * 0.5
+                let padding = 2.0
+
+                // Focus ring
+                sdf.box(0.0, 0.0, switch_width, switch_height, radius)
+                sdf.stroke(mix(vec4(0.0), self.color_border_hover, self.focus), 1.5)
+
+                // Track
+                sdf.box(1.5, 1.5, switch_width - 3.0, switch_height - 3.0, radius - 1.5)
+                let track_color_unchecked = mix(self.color_border, self.color_border_hover, self.hover)
+                sdf.fill(mix(track_color_unchecked, self.color_primary, self.checked_val))
+
+                // Knob
+                let knob_radius = radius - padding - 1.5
+                let knob_x_unchecked = padding + 1.5 + knob_radius
+                let knob_x_checked = switch_width - padding - 1.5 - knob_radius
+                let knob_x = mix(knob_x_unchecked, knob_x_checked, self.checked_val)
+                let knob_y = switch_height * 0.5
+
+                sdf.circle(knob_x, knob_y, knob_radius)
+                sdf.fill(self.color_background)
+
+                return sdf.result
+            }
+        }
+
+        draw_text +: {
+            color: (shad_theme.color_primary)
+            text_style: theme.font_regular{font_size: 11}
+        }
+
+        animator: Animator{
+            hover: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Forward {duration: 0.1}}
+                    apply: {draw_bg: {hover: 0.0}}
+                }
+                on: AnimatorState{
+                    from: {all: Snap}
+                    apply: {draw_bg: {hover: 1.0}}
+                }
+            }
+
+            focus: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Forward {duration: 0.1}}
+                    apply: {draw_bg: {focus: 0.0}}
+                }
+                on: AnimatorState{
+                    from: {all: Snap}
+                    apply: {draw_bg: {focus: 1.0}}
+                }
+            }
+
+            checked: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Forward {duration: 0.15}}
+                    apply: {draw_bg: {checked_val: 0.0}}
+                }
+                on: AnimatorState{
+                    from: {all: Forward {duration: 0.15}}
+                    apply: {draw_bg: {checked_val: 1.0}}
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum ShadSwitchAction {
+    #[default]
+    None,
+    Changed(bool),
+}
+
+#[derive(Script, Widget, Animator)]
+pub struct ShadSwitch {
+    #[uid]
+    uid: WidgetUid,
+    #[source]
+    source: ScriptObjectRef,
+    #[apply_default]
+    animator: Animator,
+
+    #[rust]
+    area: Area,
+
+    #[redraw]
+    #[live]
+    draw_bg: DrawQuad,
+    #[redraw]
+    #[live]
+    draw_text: DrawText,
+
+    #[live]
+    label: String,
+    #[live]
+    checked: bool,
+    #[live]
+    grab_key_focus: bool,
+
+    #[layout]
+    layout: Layout,
+    #[walk]
+    walk: Walk,
+
+    #[action_data]
+    #[rust]
+    action_data: WidgetActionData,
+}
+
+impl ScriptHook for ShadSwitch {
+    fn on_after_new(&mut self, vm: &mut ScriptVm) {
+        vm.with_cx_mut(|cx| {
+            self.animator_toggle(
+                cx,
+                self.checked,
+                animator::Animate::No,
+                ids!(checked.on),
+                ids!(checked.off),
+            );
+        });
+    }
+}
+
+impl Widget for ShadSwitch {
+    fn script_call(
+        &mut self,
+        vm: &mut ScriptVm,
+        method: LiveId,
+        args: ScriptValue,
+    ) -> ScriptAsyncResult {
+        if method == live_id!(set_checked) {
+            if let Some(args_obj) = args.as_object() {
+                let trap = vm.bx.threads.cur().trap.pass();
+                let value = vm.bx.heap.vec_value(args_obj, 0, trap);
+                if let Some(checked) = value.as_bool() {
+                    vm.with_cx_mut(|cx| {
+                        self.set_checked(cx, checked, animator::Animate::No);
+                    });
+                }
+            }
+            return ScriptAsyncResult::Return(NIL);
+        }
+        if method == live_id!(checked) {
+            return ScriptAsyncResult::Return(ScriptValue::from_bool(self.checked));
+        }
+        ScriptAsyncResult::MethodNotFound
+    }
+
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, _scope: &mut Scope) {
+        let uid = self.widget_uid();
+
+        if self.animator_handle_event(cx, event).must_redraw() {
+            self.area.redraw(cx);
+        }
+
+        match event.hits(cx, self.area) {
+            Hit::KeyDown(ke) => {
+                if let KeyCode::Space | KeyCode::ReturnKey = ke.key_code {
+                    self.checked = !self.checked;
+                    self.animator_toggle(
+                        cx,
+                        self.checked,
+                        animator::Animate::Yes,
+                        ids!(checked.on),
+                        ids!(checked.off),
+                    );
+                    cx.widget_action_with_data(
+                        &self.action_data,
+                        uid,
+                        ShadSwitchAction::Changed(self.checked),
+                    );
+                    self.area.redraw(cx);
+                }
+            }
+            Hit::FingerDown(_) => {
+                if self.grab_key_focus {
+                    cx.set_key_focus(self.area);
+                }
+                self.checked = !self.checked;
+                self.animator_toggle(
+                    cx,
+                    self.checked,
+                    animator::Animate::Yes,
+                    ids!(checked.on),
+                    ids!(checked.off),
+                );
+                cx.widget_action_with_data(
+                    &self.action_data,
+                    uid,
+                    ShadSwitchAction::Changed(self.checked),
+                );
+                self.area.redraw(cx);
+            }
+            Hit::KeyFocus(_) => {
+                self.animator_play(cx, ids!(focus.on));
+            }
+            Hit::KeyFocusLost(_) => {
+                self.animator_play(cx, ids!(focus.off));
+            }
+            Hit::FingerHoverIn(_) => {
+                cx.set_cursor(MouseCursor::Hand);
+                self.animator_play(cx, ids!(hover.on));
+            }
+            Hit::FingerHoverOut(_) => {
+                self.animator_play(cx, ids!(hover.off));
+            }
+            Hit::FingerUp(fe) => {
+                if fe.is_over {
+                    if fe.device.has_hovers() {
+                        self.animator_play(cx, ids!(hover.on));
+                    } else {
+                        self.animator_play(cx, ids!(hover.off));
+                    }
+                } else {
+                    self.animator_play(cx, ids!(hover.off));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, _scope: &mut Scope, walk: Walk) -> DrawStep {
+        let switch_width = 36.0;
+        let switch_height = 20.0;
+
+        let mut layout = Layout::flow_right().with_align_y(0.5);
+        layout.spacing = 8.0;
+
+        cx.begin_turtle(walk, layout);
+
+        self.draw_bg.draw_walk(cx, Walk::fixed(switch_width, switch_height));
+
+        if !self.label.is_empty() {
+            self.draw_text.draw_walk(
+                cx,
+                Walk::new(Size::fit(), Size::fit()),
+                Align { x: 0.0, y: 0.5 },
+                self.label.as_ref(),
+            );
+        }
+
+        cx.end_turtle_with_area(&mut self.area);
+        DrawStep::done()
+    }
+}
+
+impl ShadSwitch {
+    pub fn set_checked(&mut self, cx: &mut Cx, checked: bool, animate: animator::Animate) {
+        self.checked = checked;
+        self.animator_toggle(cx, checked, animate, ids!(checked.on), ids!(checked.off));
+        self.area.redraw(cx);
+    }
+
+    pub fn is_checked(&self) -> bool {
+        self.checked
+    }
+
+    pub fn changed(&self, actions: &Actions) -> Option<bool> {
+        if let Some(item) = actions.find_widget_action(self.widget_uid()) {
+            if let ShadSwitchAction::Changed(v) = item.cast() {
+                return Some(v);
+            }
+        }
+        None
+    }
+}
+
+impl ShadSwitchRef {
+    pub fn set_checked(&self, cx: &mut Cx, checked: bool, animate: animator::Animate) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_checked(cx, checked, animate);
+        }
+    }
+
+    pub fn is_checked(&self) -> bool {
+        self.borrow().is_some_and(|inner| inner.is_checked())
+    }
+
+    pub fn changed(&self, actions: &Actions) -> Option<bool> {
+        if let Some(inner) = self.borrow() {
+            inner.changed(actions)
+        } else {
+            None
+        }
+    }
+}

--- a/gallery/src/app.rs
+++ b/gallery/src/app.rs
@@ -116,6 +116,12 @@ impl MatchEvent for App {
                 .page_flip(cx, ids!(content_flip))
                 .set_active_page(cx, live_id!(label_page));
         }
+
+        if self.ui.button(cx, ids!(sidebar_switch)).clicked(actions) {
+            self.ui
+                .page_flip(cx, ids!(content_flip))
+                .set_active_page(cx, live_id!(switch_page));
+        }
     }
 }
 

--- a/gallery/src/ui/content_flip.rs
+++ b/gallery/src/ui/content_flip.rs
@@ -21,5 +21,6 @@ script_mod! {
         collapsible_page := mod.widgets.GalleryCollapsiblePage{}
         input_page := mod.widgets.GalleryInputPage{}
         label_page := mod.widgets.GalleryLabelPage{}
+        switch_page: <mod.widgets.switch_page> {}
     }
 }

--- a/gallery/src/ui/mod.rs
+++ b/gallery/src/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod input_page;
 pub mod label_page;
 pub mod root;
 pub mod sidebar;
+pub mod switch_page;
 pub mod themed_widgets;
 
 pub fn script_mod(vm: &mut ScriptVm) {
@@ -32,6 +33,7 @@ pub fn script_mod(vm: &mut ScriptVm) {
     crate::ui::collapsible_page::script_mod(vm);
     crate::ui::input_page::script_mod(vm);
     crate::ui::label_page::script_mod(vm);
+    crate::ui::switch_page::script_mod(vm);
     crate::ui::content_flip::script_mod(vm);
     crate::ui::root::script_mod(vm);
 }

--- a/gallery/src/ui/sidebar.rs
+++ b/gallery/src/ui/sidebar.rs
@@ -53,6 +53,7 @@ script_mod! {
             sidebar_collapsible := mod.widgets.GallerySidebarItem{text: "Collapsible"}
             sidebar_input := mod.widgets.GallerySidebarItem{text: "Input"}
             sidebar_label := mod.widgets.GallerySidebarItem{text: "Label"}
+            sidebar_switch := SidebarButton { text: "Switch" }
         }
     }
 }

--- a/gallery/src/ui/switch_page.rs
+++ b/gallery/src/ui/switch_page.rs
@@ -1,0 +1,58 @@
+use makepad_components::makepad_widgets::*;
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use makepad_components::switch::*
+    use crate::ui::themed_widgets::*
+
+    mod.widgets.switch_page = {
+        flow: Down
+        spacing: 20
+        padding: 20
+        align: {x: 0.0, y: 0.0}
+
+        Label {
+            text: "Switch"
+            draw_text: {
+                text_style: {font_size: 24.0}
+            }
+        }
+
+        Label {
+            text: "A control that allows the user to toggle between checked and not checked."
+            draw_text: {
+                color: (shad_theme.color_muted_foreground)
+                text_style: {font_size: 14.0}
+            }
+        }
+
+        View {
+            flow: Right
+            spacing: 20
+
+            View {
+                flow: Down
+                spacing: 15
+                align: {x: 0.0, y: 0.0}
+
+                Label {
+                    text: "Default"
+                    draw_text: {
+                        text_style: {font_size: 16.0}
+                    }
+                }
+
+                ShadSwitch {
+                    label: "Airplane Mode"
+                }
+                ShadSwitch {
+                    label: "Wi-Fi"
+                    checked: true
+                }
+                ShadSwitch {
+                    label: "Bluetooth"
+                }
+            }
+        }
+    }
+}

--- a/gallery_output.log
+++ b/gallery_output.log
@@ -1,0 +1,100 @@
+warning: skipping duplicate package `bitflags v2.10.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)`:
+  /home/jules/.cargo/git/checkouts/makepad-ec2f134f34cd9f98/8b51533/libs/vulkan/bitflags/Cargo.toml
+in favor of /home/jules/.cargo/git/checkouts/makepad-ec2f134f34cd9f98/8b51533/libs/bitflags/Cargo.toml
+
+   Compiling makepad-micro-proc-macro v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling proc-macro2 v1.0.106
+   Compiling unicode-ident v1.0.24
+   Compiling quote v1.0.45
+   Compiling pkg-config v0.3.32
+   Compiling libc v0.2.182
+   Compiling makepad-live-id-macros v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-micro-serde-derive v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-live-id v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling wayland-sys v0.31.8 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-micro-serde v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling syn v2.0.117
+   Compiling log v0.4.29
+   Compiling autocfg v1.5.0
+   Compiling libm v0.2.16
+   Compiling makepad-script-derive v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling wayland-backend v0.3.12 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling num-traits v0.2.19
+   Compiling makepad-error-log v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-html v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling smallvec v1.15.1 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling downcast-rs v1.2.1
+   Compiling smallvec v1.15.1
+   Compiling bitflags v2.11.0
+   Compiling zerocopy v0.8.40
+   Compiling scoped-tls v1.0.1
+   Compiling makepad-math v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-regex v0.1.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling zerocopy-derive v0.8.40
+   Compiling thiserror v2.0.18
+   Compiling cfg_aliases v0.2.1
+   Compiling wayland-client v0.31.12 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling bitflags v2.10.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling foldhash v0.2.0
+   Compiling makepad-script v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling hashbrown v0.16.1
+   Compiling naga v27.0.3
+   Compiling thiserror-impl v2.0.18
+   Compiling cfg-if v1.0.4
+   Compiling unicode-width v0.2.2
+   Compiling makepad-zune-core v0.5.1 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling simd-adler32 v0.3.8 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling bit-vec v0.8.0
+   Compiling equivalent v1.0.2
+   Compiling indexmap v2.13.0
+   Compiling bit-set v0.8.0
+   Compiling makepad-zune-inflate v0.2.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling codespan-reporting v0.12.0
+   Compiling spirv v0.3.0+sdk-1.3.268.0
+   Compiling half v2.7.1
+   Compiling once_cell v1.21.3
+   Compiling rustc-hash v1.1.0
+   Compiling ttf-parser v0.24.1 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling hexf-parse v0.2.1
+   Compiling arrayvec v0.7.6
+   Compiling makepad-platform v2.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling wayland-protocols v0.32.10 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-studio-protocol v0.1.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-network v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-zune-png v0.5.1 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling wayland-egl v0.32.9 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-properties v0.1.4 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling pulldown-cmark v0.12.2 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-ccc v0.3.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-bidi-mirroring v0.3.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-futures v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling bytemuck v1.25.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-script v0.5.8 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-byteorder-lite v0.1.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling byteorder v1.5.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-webp v0.2.4 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling fxhash v0.2.1 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling rustybuzz v0.18.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-zune-jpeg v0.5.12 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-svg v1.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling memchr v2.7.6 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling ab_glyph_rasterizer v0.1.8 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-segmentation v1.12.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-bidi v0.3.18 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling sdfer v0.2.1 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicase v2.9.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-widgets v2.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling unicode-linebreak v0.1.5 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-draw v2.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-derive-widget v2.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-latex-math v0.1.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-icon v1.0.0 (/app/makepad-icon)
+   Compiling makepad-components v1.0.0 (/app/components)
+   Compiling makepad-code-editor v2.0.0 (https://github.com/makepad/makepad.git?branch=dev#8b515338)
+   Compiling makepad-example-component-gallery v1.0.0 (/app/gallery)
+    Finished `release` profile [optimized] target(s) in 1m 40s
+     Running `target/release/makepad-example-component-gallery`
+WAYLAND_DISPLAY: Not set
+DISPLAY: Not set
+Selected: X11 backend
+Reason: Default fallback (no display variables set)


### PR DESCRIPTION
Adds a Shadcn-inspired switch component to the `makepad-components` library and showcases it in the gallery app. The switch supports hover, focus, and checked states with fluid animations, utilizing the `shad_theme` tokens.

---
*PR created automatically by Jules for task [2746780881096130629](https://jules.google.com/task/2746780881096130629) started by @wheregmis*