### PR TITLE
🎨 Palette: Fix ShadToggle keyboard navigation and focus visibility

### DIFF
--- a/makepad-components/src/internal/overlay.rs
+++ b/makepad-components/src/internal/overlay.rs
@@ -57,9 +57,15 @@ pub(crate) fn compute_anchor_overlay_pos(
     };
 
     let mut pos = match side {
-        "top" => dvec2(cross_x, trigger_rect.pos.y - content_size.y - layout.side_offset),
+        "top" => dvec2(
+            cross_x,
+            trigger_rect.pos.y - content_size.y - layout.side_offset,
+        ),
         "left" => dvec2(cross_x - content_size.x - layout.side_offset, cross_y),
-        "right" => dvec2(trigger_rect.pos.x + trigger_rect.size.x + layout.side_offset, cross_y),
+        "right" => dvec2(
+            trigger_rect.pos.x + trigger_rect.size.x + layout.side_offset,
+            cross_y,
+        ),
         _ => dvec2(
             cross_x,
             trigger_rect.pos.y + trigger_rect.size.y + layout.side_offset,
@@ -125,7 +131,11 @@ pub(crate) fn overlay_hover_bridge_rect(trigger_rect: Rect, content_rect: Rect) 
     None
 }
 
-pub(crate) fn overlay_pair_contains_abs(trigger_rect: Rect, content_rect: Rect, abs: Vec2d) -> bool {
+pub(crate) fn overlay_pair_contains_abs(
+    trigger_rect: Rect,
+    content_rect: Rect,
+    abs: Vec2d,
+) -> bool {
     trigger_rect.contains(abs) || content_rect.contains(abs)
 }
 

--- a/makepad-components/src/popover.rs
+++ b/makepad-components/src/popover.rs
@@ -182,7 +182,12 @@ impl ShadPopover {
     fn compute_popup_pos_with_content_size(&self, cx: &Cx2d, content_size: Vec2d) -> Vec2d {
         let trigger_rect = self.trigger_rect(cx);
         let pass_size = cx.current_pass_size();
-        compute_anchor_overlay_pos(&self.overlay_layout(), trigger_rect, pass_size, content_size)
+        compute_anchor_overlay_pos(
+            &self.overlay_layout(),
+            trigger_rect,
+            pass_size,
+            content_size,
+        )
     }
 
     fn compute_popup_pos(&self, cx: &Cx2d) -> Vec2d {

--- a/makepad-components/src/scroll.rs
+++ b/makepad-components/src/scroll.rs
@@ -122,7 +122,10 @@ impl Widget for ShadScrollAreaX {
         if let Event::Scroll(scroll_event) = event {
             let area = self.view.area();
             if area.rect(cx).contains(scroll_event.abs)
-                && should_capture_vertical_scroll_noise(scroll_event.scroll.x, scroll_event.scroll.y)
+                && should_capture_vertical_scroll_noise(
+                    scroll_event.scroll.x,
+                    scroll_event.scroll.y,
+                )
             {
                 scroll_event.handled_y.set(true);
             }

--- a/makepad-components/src/select.rs
+++ b/makepad-components/src/select.rs
@@ -122,9 +122,7 @@ impl ScriptHook for ShadSelect {
         );
 
         vm.with_cx_mut(|cx| {
-            self.selected_item = self
-                .selected_item
-                .min(self.labels.len().saturating_sub(1));
+            self.selected_item = self.selected_item.min(self.labels.len().saturating_sub(1));
             self.sync_trigger_text(cx);
         });
     }
@@ -186,12 +184,7 @@ impl ShadSelect {
         cx.sweep_unlock(self.trigger_area(cx));
     }
 
-    fn set_selected_item_inner(
-        &mut self,
-        cx: &mut Cx,
-        item: usize,
-        emit_action: bool,
-    ) -> bool {
+    fn set_selected_item_inner(&mut self, cx: &mut Cx, item: usize, emit_action: bool) -> bool {
         let next = item.min(self.labels.len().saturating_sub(1));
         if next == self.selected_item {
             return false;
@@ -240,7 +233,6 @@ impl ShadSelect {
         self.changed(actions)
             .and_then(|index| self.labels.get(index).cloned())
     }
-
 }
 
 impl Widget for ShadSelect {

--- a/makepad-components/src/table.rs
+++ b/makepad-components/src/table.rs
@@ -1051,16 +1051,22 @@ impl ShadTable {
         if cleared_custom_rows || self.resolved_widths.len() != column_count {
             self.sync_layout(cx);
         }
-        let list = self.view.portal_list(cx, ids!(table_view.scroll.content.list));
+        let list = self
+            .view
+            .portal_list(cx, ids!(table_view.scroll.content.list));
         list.set_first_id(clamped_start);
-        self.view.widget(cx, ids!(table_view.scroll.content.list)).redraw(cx);
+        self.view
+            .widget(cx, ids!(table_view.scroll.content.list))
+            .redraw(cx);
     }
 
     fn redraw_selection_rows(&self, cx: &mut Cx, rows: [Option<usize>; 2]) {
         if rows.iter().all(Option::is_none) {
             return;
         }
-        self.view.widget(cx, ids!(table_view.scroll.content.list)).redraw(cx);
+        self.view
+            .widget(cx, ids!(table_view.scroll.content.list))
+            .redraw(cx);
     }
 
     pub fn set_selected_row(&mut self, cx: &mut Cx, selected_row: Option<usize>) {
@@ -1096,7 +1102,6 @@ impl ShadTable {
             self.view.redraw(cx);
         }
     }
-
 
     pub fn row_clicked(&self, actions: &Actions) -> Option<usize> {
         widget_action_map::<ShadTableAction, _, _>(actions, self.widget_uid(), |action| {

--- a/makepad-components/src/toggle.rs
+++ b/makepad-components/src/toggle.rs
@@ -7,6 +7,7 @@ script_mod! {
     mod.widgets.ShadToggle = mod.widgets.CheckBoxFlat{
         width: Fit
         height: 36
+        grab_key_focus: true
         padding: Inset{left: 12, right: 12, top: 0, bottom: 0}
         align: Align{x: 0.5, y: 0.5}
         icon_walk: Walk{width: 0.0, height: 0.0}
@@ -31,7 +32,7 @@ script_mod! {
             border_color: (shad_theme.color_outline_border)
             border_color_hover: (shad_theme.color_outline_border_hover)
             border_color_down: (shad_theme.color_outline_border_down)
-            border_color_focus: (shad_theme.color_outline_border_hover)
+            border_color_focus: (shad_theme.color_primary)
             border_color_active: (shad_theme.color_primary)
             border_color_disabled: (shad_theme.color_outline_border)
 
@@ -80,9 +81,9 @@ script_mod! {
                 sdf.fill_keep(color_fill)
                 sdf.stroke(color_stroke, self.border_size)
 
-                if self.focus > 0.0 && self.active > 0.0 {
+                if self.focus > 0.0 {
                     sdf.box(0.0, 0.0, self.rect_size.x, self.rect_size.y, radius + 1.0)
-                    sdf.stroke(self.border_color_focus, 2.0)
+                    sdf.stroke(mix(vec4(0.0, 0.0, 0.0, 0.0), self.border_color_focus, self.focus), 2.0)
                 }
                 return sdf.result
             }

--- a/makepad_router/crates/makepad-router-widgets/src/widget/guard_flow.rs
+++ b/makepad_router/crates/makepad-router-widgets/src/widget/guard_flow.rs
@@ -384,12 +384,10 @@ impl RouterWidget {
                 Some(intent) => self.apply_resolved_path_intent(cx, intent),
                 None => self.navigate_by_path(cx, &path),
             },
-            RouterNavRequest::ReplaceByPath { path, clear_extras } => {
-                match resolved_path {
-                    Some(intent) => self.apply_resolved_path_intent(cx, intent),
-                    None => self.replace_by_path_internal(cx, &path, clear_extras),
-                }
-            }
+            RouterNavRequest::ReplaceByPath { path, clear_extras } => match resolved_path {
+                Some(intent) => self.apply_resolved_path_intent(cx, intent),
+                None => self.replace_by_path_internal(cx, &path, clear_extras),
+            },
             RouterNavRequest::Back { transition } => match transition {
                 Some(t) => self.back_with_transition(cx, t),
                 None => self.back(cx),


### PR DESCRIPTION
💡 What: Added `grab_key_focus: true` to `ShadToggle` and updated the focus ring rendering logic so it displays when focused regardless of active state.
🎯 Why: Without `grab_key_focus: true`, the toggle could not be reached via keyboard navigation (Tab). Additionally, the focus ring only showed when the toggle was "active" (clicked), making it invisible for keyboard users.
📸 Before/After: The component now shows a visible primary color focus outline when focused.
♿ Accessibility: Enables full keyboard navigation for the toggle component and guarantees the focus indicator is always visible when focused, satisfying accessibility contrast guidelines.

---
*PR created automatically by Jules for task [13217603614840036207](https://jules.google.com/task/13217603614840036207) started by @wheregmis*