### PR TITLE
🧹 Remove dead code allow attribute in gallery root

### DIFF
--- a/makepad-gallery/src/ui/root.rs
+++ b/makepad-gallery/src/ui/root.rs
@@ -18,7 +18,7 @@ macro_rules! define_gallery_root {
             }
         )*
     ) => {
-        #[cfg_attr(not(test), allow(dead_code))]
+        #[cfg(test)]
         pub const ROUTER_BINDINGS: &[(LiveId, &str)] = &[
             $((live_id!($page), $route),)*
         ];


### PR DESCRIPTION
🎯 **What:** Removed the `allow(dead_code)` attribute on the `ROUTER_BINDINGS` constant in `makepad-gallery/src/ui/root.rs` and replaced it with `#[cfg(test)]`.

💡 **Why:** `ROUTER_BINDINGS` is only ever referenced and used in `makepad-gallery/src/ui/catalog.rs` inside the `tests` module. Instead of compiling it in non-test builds and telling the compiler to suppress the dead code warning, the idiomatic and cleaner approach is to use `#[cfg(test)]` so that the constant is only compiled into the binary during test runs. This improves code cleanliness, removes unnecessary suppression attributes, and ensures tests have strictly what they need.

✅ **Verification:** Verified by compiling standard and test builds (`cargo check -p makepad-gallery --locked` and `cargo test -p makepad-gallery --locked`), confirming no new compilation warnings or failures were introduced. All tests pass successfully.

✨ **Result:** A small code health improvement that accurately aligns code visibility with its actual usage, simplifying the `define_gallery_root` macro implementation.

---
*PR created automatically by Jules for task [18222119765492035491](https://jules.google.com/task/18222119765492035491) started by @wheregmis*