### PR TITLE
⚡ Bolt: Optimize RouterAction clone in path navigation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -85,3 +85,10 @@
 ## 2026-04-18 - Route actions reordering eliminates RouterAction cloning
 **Learning:** In `makepad-router-widgets/src/widget/api.rs`, navigating queues a `RouterAction` and syncs the browser URL. The previous flow called `queue_route_actions` (consuming an owned clone) before `sync_browser_with_action` (which takes a reference). Because `RouterAction` wraps `Route` (which allocates strings and hash maps for parameters), this extra clone caused unnecessary heap allocations on every route change.
 **Action:** Reorder synchronous side-effects where possible to let a consuming function run last. By borrowing the `RouterAction` for browser sync first, we can directly move the un-cloned owned value into the queue.
+## 2026-04-17 - Eliminate RouterAction Clone in Path Navigation
+**Learning:** In Makepad routing, when dispatching a route action,  consumes the action (moving it into a ). However,  only requires a reference (). If they are called in the wrong order (queue then sync), it necessitates an expensive clone of , which intern clones the  object and its heap-allocated parameters/queries.
+**Action:** Always perform side-effects that take references before side-effects that take ownership. Swap the execution order of  and  to eliminate unnecessary deep cloning in hot paths.
+
+## 2025-02-14 - Eliminate RouterAction Clone in Path Navigation
+**Learning:** In Makepad routing, when dispatching a route action, `queue_route_actions` consumes the action (moving it into a `Vec`). However, `sync_browser_with_action` only requires a reference (`&RouterAction`). If they are called in the wrong order (queue then sync), it necessitates an expensive clone of `RouterAction`, which intern clones the `Route` object and its heap-allocated parameters/queries.
+**Action:** Always perform side-effects that take references before side-effects that take ownership. Swap the execution order of `sync_browser_with_action` and `queue_route_actions` to eliminate unnecessary deep cloning in hot paths.

--- a/makepad_router/crates/makepad-router-widgets/src/widget/path_nav.rs
+++ b/makepad_router/crates/makepad-router-widgets/src/widget/path_nav.rs
@@ -134,12 +134,15 @@ impl RouterWidget {
         } else {
             RouterAction::Navigate(route.clone())
         };
+        // Optimization: avoid unnecessary allocation by borrowing RouterAction before consuming it
+        // Previously: queued actions first using `primary_action.clone()`, then synced browser
+        // Now: sync browser first (borrows), then queue (consumes), eliminating a full `Route` clone
+        self.sync_browser_with_action(cx, &primary_action);
         self.queue_route_actions(
-            Some(primary_action.clone()),
+            Some(primary_action),
             old_route.as_ref().map(|r| r.id),
             &route,
         );
-        self.sync_browser_with_action(cx, &primary_action);
 
         match &intent.kind {
             ResolvedPathKind::NestedPrefix { tail } => {


### PR DESCRIPTION
💡 What: Swapped the execution order of `sync_browser_with_action` and `queue_route_actions` in `makepad-router-widgets/src/widget/path_nav.rs` to eliminate an unnecessary `.clone()` call on `RouterAction`.
🎯 Why: `queue_route_actions` consumes the action (moving it into a `Vec`), while `sync_browser_with_action` only borrows it. By doing the borrow first, we avoid cloning the entire `Route` (which contains heap-allocated paths and HashMaps for queries) during navigation resolution, effectively eliminating a costly allocation in the routing hot path.
📊 Impact: Reduces heap allocations and deep object copying (String paths, HashMap parameters) every time a path is resolved and applied, making the router faster and leaner.
🔬 Measurement: Verified the logic using Cargo check/test and noted the avoided memory churn as a theoretical maximum of one full `Route` allocation skipped per path navigation event.
🧪 Verification: `cargo test -p makepad-router-widgets` and `cargo clippy` passed cleanly.

---
*PR created automatically by Jules for task [11961230008497288668](https://jules.google.com/task/11961230008497288668) started by @wheregmis*