### PR TITLE
⚡ Bolt: Eliminate `Route` clones in `dispatch_route_change`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -92,3 +92,6 @@
 ## 2025-02-14 - Eliminate RouterAction Clone in Path Navigation
 **Learning:** In Makepad routing, when dispatching a route action, `queue_route_actions` consumes the action (moving it into a `Vec`). However, `sync_browser_with_action` only requires a reference (`&RouterAction`). If they are called in the wrong order (queue then sync), it necessitates an expensive clone of `RouterAction`, which intern clones the `Route` object and its heap-allocated parameters/queries.
 **Action:** Always perform side-effects that take references before side-effects that take ownership. Swap the execution order of `sync_browser_with_action` and `queue_route_actions` to eliminate unnecessary deep cloning in hot paths.
+## 2024-04-18 – Eliminate Route clones in makepad-router
+**Learning:** In event-heavy UI architectures, routing callback loops (`for callback in &callbacks`) that pass complex values (like `Route`, which contains `HashMap` allocations for queries and params) can cause significant, unnecessary heap churn on every layout or interaction frame.
+**Action:** When designing observer or callback APIs (e.g., `on_route_change`), prefer passing arguments by reference (`&T` or `Option<&T>`) instead of consuming `T` or enforcing `.clone()` at the dispatch site, especially for structs holding heap-allocated collections.

--- a/makepad_router/crates/makepad-router-widgets/src/widget.rs
+++ b/makepad_router/crates/makepad-router-widgets/src/widget.rs
@@ -608,7 +608,7 @@ impl RouterWidgetRef {
     /// Register a route change callback
     pub fn on_route_change<F>(&self, callback: F)
     where
-        F: Fn(&mut Cx, Option<Route>, Route) + Send + Sync + 'static,
+        F: Fn(&mut Cx, Option<&Route>, &Route) + Send + Sync + 'static,
     {
         if let Some(mut inner) = self.borrow_mut() {
             inner.on_route_change(callback);

--- a/makepad_router/crates/makepad-router-widgets/src/widget/callbacks.rs
+++ b/makepad_router/crates/makepad-router-widgets/src/widget/callbacks.rs
@@ -6,7 +6,7 @@ use super::RouterWidget;
 impl RouterWidget {
     pub fn on_route_change<F>(&mut self, callback: F)
     where
-        F: Fn(&mut Cx, Option<Route>, Route) + Send + Sync + 'static,
+        F: Fn(&mut Cx, Option<&Route>, &Route) + Send + Sync + 'static,
     {
         self.callbacks.route_change.push(Box::new(callback));
     }
@@ -20,8 +20,11 @@ impl RouterWidget {
         if self.callbacks.route_change.is_empty() {
             return;
         }
+        // Optimization: prevent unnecessary heap allocations in routing callback dispatch
+        // Previously: called `callback(cx, old_route.cloned(), new_route.clone())`, which allocated memory for queries and params
+        // Now: pass `Route` by reference to the callback, eliminating costly clones per frame
         for callback in &self.callbacks.route_change {
-            callback(cx, old_route.cloned(), new_route.clone());
+            callback(cx, old_route, new_route);
         }
     }
 }

--- a/makepad_router/crates/makepad-router-widgets/src/widget/fields.rs
+++ b/makepad_router/crates/makepad-router-widgets/src/widget/fields.rs
@@ -11,7 +11,7 @@ use crate::guards::{
 };
 use crate::route::Route;
 
-type RouteChangeCallback = Box<dyn Fn(&mut Cx, Option<Route>, Route) + Send + Sync>;
+type RouteChangeCallback = Box<dyn Fn(&mut Cx, Option<&Route>, &Route) + Send + Sync>;
 
 #[derive(Default)]
 pub(crate) struct RouterCallbacks {


### PR DESCRIPTION
💡 What: Changed the `on_route_change` callback signature to accept `Route` parameters by reference (`Option<&Route>` and `&Route`) instead of by value, avoiding costly `.clone()` calls during callback dispatch.

🎯 Why: `Route` contains `HashMap` instances for queries and parameters. Passing it by value to multiple callbacks required full string/heap clones on every dispatch, causing unnecessary memory allocation and overhead during hot UI frames.

📊 Impact: Eliminates `Route` heap allocations per registered callback during every route dispatch cycle, directly addressing a documented measurement showing massive cost differences over 100,000 iterations.

🔬 Measurement: Identified cost using `clone_cost_measurement` test benchmarks included in `callbacks.rs`.

🧪 Verification: Ran `cargo check -p makepad-router-widgets` and `cargo test -p makepad-router-widgets` to ensure callbacks trigger successfully with references without breaking downstream logic.

---
*PR created automatically by Jules for task [14475503573463263808](https://jules.google.com/task/14475503573463263808) started by @wheregmis*