### PR TITLE
Add labels to mobile sidebar controls

### DIFF
--- a/makepad-gallery/src/main.rs
+++ b/makepad-gallery/src/main.rs
@@ -268,6 +268,18 @@ impl App {
                 ],
             )
             .key_focus(cx);
+        let close_label_has_focus = self
+            .ui
+            .button(
+                cx,
+                &[
+                    live_id!(mobile_sidebar_panel),
+                    live_id!(sidebar_mobile),
+                    live_id!(mobile_sidebar_close_button),
+                    live_id!(label_button),
+                ],
+            )
+            .key_focus(cx);
         let sidebar_item_has_focus = catalog::entries().iter().any(|entry| {
             self.ui
                 .widget(
@@ -281,7 +293,7 @@ impl App {
                 .key_focus(cx)
         });
 
-        if close_button_has_focus || sidebar_item_has_focus {
+        if close_button_has_focus || close_label_has_focus || sidebar_item_has_focus {
             cx.set_key_focus(Area::Empty);
         }
     }
@@ -537,10 +549,34 @@ impl MatchEvent for App {
                     .button(
                         cx,
                         &[
+                            live_id!(responsive_header),
+                            live_id!(Mobile),
+                            live_id!(mobile_sidebar_menu_button),
+                            live_id!(label_button),
+                        ],
+                    )
+                    .clicked(actions)
+                || self
+                    .ui
+                    .button(
+                        cx,
+                        &[
                             live_id!(mobile_sidebar_panel),
                             live_id!(sidebar_mobile),
                             live_id!(mobile_sidebar_close_button),
                             live_id!(button),
+                        ],
+                    )
+                    .clicked(actions)
+                || self
+                    .ui
+                    .button(
+                        cx,
+                        &[
+                            live_id!(mobile_sidebar_panel),
+                            live_id!(sidebar_mobile),
+                            live_id!(mobile_sidebar_close_button),
+                            live_id!(label_button),
                         ],
                     )
                     .clicked(actions)

--- a/makepad-gallery/src/ui/command_palette.rs
+++ b/makepad-gallery/src/ui/command_palette.rs
@@ -447,7 +447,11 @@ impl GalleryCommandPalette {
         }
 
         // Fallback for any trailing entries not in cache
-        for (index, command) in catalog::entries().iter().enumerate().skip(search_terms.len()) {
+        for (index, command) in catalog::entries()
+            .iter()
+            .enumerate()
+            .skip(search_terms.len())
+        {
             if query.is_empty()
                 || command.title.to_ascii_lowercase().contains(&query)
                 || command.section.to_ascii_lowercase().contains(&query)

--- a/makepad-gallery/src/ui/sidebar.rs
+++ b/makepad-gallery/src/ui/sidebar.rs
@@ -23,18 +23,26 @@ macro_rules! define_gallery_sidebar {
             use mod.widgets.*
 
             mod.widgets.GalleryMobileSidebarIconButton = View{
-                width: 36
+                width: Fit
                 height: 36
-                flow: Overlay
-                align: Align{x: 0.5, y: 0.5}
+                flow: Right
+                align: Align{y: 0.5}
+                spacing: 8.0
 
                 button := ShadButtonIconOutline{
-                    width: Fill
+                    width: 36
                     height: Fill
+                }
+
+                label := ShadLabel{
+                    text: "Action"
+                    draw_text.text_style.font_size: 12
+                    draw_text.color: (shad_theme.color_muted_foreground)
                 }
             }
 
             mod.widgets.GalleryMobileSidebarMenuButton = mod.widgets.GalleryMobileSidebarIconButton{
+                label = ShadLabel{text: "Menu"}
                 icon := IconMenu{
                     width: 18
                     height: 18
@@ -44,6 +52,7 @@ macro_rules! define_gallery_sidebar {
             }
 
             mod.widgets.GalleryMobileSidebarCloseButton = mod.widgets.GalleryMobileSidebarIconButton{
+                label = ShadLabel{text: "Close"}
                 icon := IconX{
                     width: 16
                     height: 16

--- a/makepad-gallery/src/ui/sidebar.rs
+++ b/makepad-gallery/src/ui/sidebar.rs
@@ -34,15 +34,17 @@ macro_rules! define_gallery_sidebar {
                     height: Fill
                 }
 
-                label := ShadLabel{
+                label_button := ShadButtonLink{
                     text: "Action"
+                    height: Fill
+                    padding: Inset{left: 0, right: 0, top: 0, bottom: 0}
                     draw_text.text_style.font_size: 12
                     draw_text.color: (shad_theme.color_muted_foreground)
                 }
             }
 
             mod.widgets.GalleryMobileSidebarMenuButton = mod.widgets.GalleryMobileSidebarIconButton{
-                label = ShadLabel{text: "Menu"}
+                label_button = ShadButtonLink{text: "Menu"}
                 icon := IconMenu{
                     width: 18
                     height: 18
@@ -52,7 +54,7 @@ macro_rules! define_gallery_sidebar {
             }
 
             mod.widgets.GalleryMobileSidebarCloseButton = mod.widgets.GalleryMobileSidebarIconButton{
-                label = ShadLabel{text: "Close"}
+                label_button = ShadButtonLink{text: "Close"}
                 icon := IconX{
                     width: 16
                     height: 16


### PR DESCRIPTION
## Summary
- Make the mobile sidebar menu and close buttons explicit by adding persistent `Menu` and `Close` labels next to their icons.
- Keep the existing interaction model intact while improving first-run clarity on the compact gallery shell.
- Preserve the command palette fallback loop cleanup from the same patch set.

## Testing
- Formatting passed.
- Gallery tests passed.
- Clippy still reports a pre-existing `needless_return` in `makepad-components/src/select.rs`, unrelated to this change.