### PR TITLE
Add a visible theme label to the gallery toggle

### DIFF
--- a/makepad-components/src/button.rs
+++ b/makepad-components/src/button.rs
@@ -615,7 +615,6 @@ impl Widget for ShadNavButton {
         self.draw_bg.end(cx);
         self.area = self.draw_bg.area();
 
-
         DrawStep::done()
     }
 

--- a/makepad-gallery/src/ui/command_palette.rs
+++ b/makepad-gallery/src/ui/command_palette.rs
@@ -447,7 +447,11 @@ impl GalleryCommandPalette {
         }
 
         // Fallback for any trailing entries not in cache
-        for (index, command) in catalog::entries().iter().enumerate().skip(search_terms.len()) {
+        for (index, command) in catalog::entries()
+            .iter()
+            .enumerate()
+            .skip(search_terms.len())
+        {
             if query.is_empty()
                 || command.title.to_ascii_lowercase().contains(&query)
                 || command.section.to_ascii_lowercase().contains(&query)

--- a/makepad-gallery/src/ui/root.rs
+++ b/makepad-gallery/src/ui/root.rs
@@ -28,40 +28,69 @@ macro_rules! define_gallery_root {
             use mod.draw.KeyCode
             use mod.widgets.*
 
-            mod.widgets.GalleryThemeToggleButton = View{
+            mod.widgets.GalleryThemeToggleSun = View{
                 width: Fit
                 height: 36
-                flow: Right
-                align: Align{y: 0.5}
-                spacing: 8.0
+                flow: Overlay
+                align: Center
 
                 button := mod.widgets.ShadButtonIconOutline{
-                    width: 36
+                    width: Fill
                     height: Fill
                 }
 
-                theme_copy := ShadSectionHeader{
-                    text: "Theme"
-                    draw_text.color: (shad_theme.color_muted_foreground)
-                    draw_text.text_style.font_size: 11
+                content := View{
+                    width: Fit
+                    height: Fit
+                    flow: Right
+                    align: Align{y: 0.5}
+                    spacing: 8.0
+
+                    icon := IconSun{
+                        width: 16
+                        height: 16
+                        icon_walk: Walk{width: 16, height: 16}
+                        draw_icon.color: (shad_theme.color_primary)
+                    }
+
+                    theme_copy := ShadSectionHeader{
+                        text: "Theme"
+                        draw_text.color: (shad_theme.color_muted_foreground)
+                        draw_text.text_style.font_size: 11
+                    }
                 }
             }
 
-            mod.widgets.GalleryThemeToggleSun = mod.widgets.GalleryThemeToggleButton{
-                icon := IconSun{
-                    width: 16
-                    height: 16
-                    icon_walk: Walk{width: 16, height: 16}
-                    draw_icon.color: (shad_theme.color_primary)
-                }
-            }
+            mod.widgets.GalleryThemeToggleMoon = View{
+                width: Fit
+                height: 36
+                flow: Overlay
+                align: Center
 
-            mod.widgets.GalleryThemeToggleMoon = mod.widgets.GalleryThemeToggleButton{
-                icon := IconMoon{
-                    width: 16
-                    height: 16
-                    icon_walk: Walk{width: 16, height: 16}
-                    draw_icon.color: (shad_theme.color_primary)
+                button := mod.widgets.ShadButtonIconOutline{
+                    width: Fill
+                    height: Fill
+                }
+
+                content := View{
+                    width: Fit
+                    height: Fit
+                    flow: Right
+                    align: Align{y: 0.5}
+                    spacing: 8.0
+
+                    icon := IconMoon{
+                        width: 16
+                        height: 16
+                        icon_walk: Walk{width: 16, height: 16}
+                        draw_icon.color: (shad_theme.color_primary)
+                    }
+
+                    theme_copy := ShadSectionHeader{
+                        text: "Theme"
+                        draw_text.color: (shad_theme.color_muted_foreground)
+                        draw_text.text_style.font_size: 11
+                    }
                 }
             }
 

--- a/makepad-gallery/src/ui/root.rs
+++ b/makepad-gallery/src/ui/root.rs
@@ -29,14 +29,21 @@ macro_rules! define_gallery_root {
             use mod.widgets.*
 
             mod.widgets.GalleryThemeToggleButton = View{
-                width: 36
+                width: Fit
                 height: 36
-                flow: Overlay
-                align: Align{x: 0.5, y: 0.5}
+                flow: Right
+                align: Align{y: 0.5}
+                spacing: 8.0
 
                 button := mod.widgets.ShadButtonIconOutline{
-                    width: Fill
+                    width: 36
                     height: Fill
+                }
+
+                theme_copy := ShadSectionHeader{
+                    text: "Theme"
+                    draw_text.color: (shad_theme.color_muted_foreground)
+                    draw_text.text_style.font_size: 11
                 }
             }
 


### PR DESCRIPTION
## Summary
- Make the gallery shell theme toggle read as a labeled control instead of an icon-only affordance.
- Keep the existing button behavior and layout intact while improving clarity in the shared header.
- Include a small formatting cleanup in the command palette fallback iterator and nav button render path.

## Testing
- Unit tests: passed for the gallery crate.
- UI testing: not run (not requested).