### PR TITLE
🎨 Palette: Add aria labels to icon buttons

### DIFF
--- a/makepad-components/src/carousel.rs
+++ b/makepad-components/src/carousel.rs
@@ -65,6 +65,7 @@ script_mod! {
     mod.widgets.ShadCarouselPrevBtn = mod.widgets.IconButtonChevronLeft{
         width: 32
         height: 32
+        aria_label: "Previous slide"
         draw_bg +: {
             color: (shad_theme.color_background)
             color_hover: (shad_theme.color_secondary)
@@ -83,6 +84,7 @@ script_mod! {
     mod.widgets.ShadCarouselNextBtn = mod.widgets.IconButtonChevronRight{
         width: 32
         height: 32
+        aria_label: "Next slide"
         draw_bg +: {
             color: (shad_theme.color_background)
             color_hover: (shad_theme.color_secondary)

--- a/makepad-icon/src/icons.rs
+++ b/makepad-icon/src/icons.rs
@@ -21,6 +21,7 @@ macro_rules! define_lucide_icons {
             // Callers apply draw_bg / draw_icon.color styling on top.
             mod.widgets.IconButtonX = mod.widgets.ButtonFlatIcon{
                 icon_walk: Walk{width: 14, height: 14}
+                aria_label: "Close"
                 draw_icon.svg: crate_resource("self://resources/icons/x.svg")
             }
 


### PR DESCRIPTION
💡 What: Added aria labels to icon-only buttons (`IconButtonX`, `ShadCarouselPrevBtn`, `ShadCarouselNextBtn`)
🎯 Why: Icon-only buttons without labels are inaccessible to screen readers and lack necessary semantic context for keyboard navigation.
♻️ Accessibility: Improves discoverability and usability of icon-only elements across the component gallery and downstream usages.

---
*PR created automatically by Jules for task [5670187435837559516](https://jules.google.com/task/5670187435837559516) started by @wheregmis*