### PR TITLE
🎨 Palette: Add focus ring to ShadRadioItem

### DIFF
--- a/makepad-components/src/radio_group.rs
+++ b/makepad-components/src/radio_group.rs
@@ -47,6 +47,51 @@ script_mod! {
             mark_color: #0000
             mark_color_active: (shad_theme.color_primary)
             mark_color_disabled: (shad_theme.color_muted_foreground)
+
+            pixel: fn() {
+                let sdf = Sdf2d.viewport(self.pos * self.rect_size)
+
+                let sz_px = self.size
+                let radius_px = sz_px * 0.5
+                let center_px = vec2(radius_px, self.rect_size.y * 0.5)
+
+                // Draw background circle
+                sdf.circle(center_px.x, center_px.y, radius_px - self.border_size)
+
+                let color_fill = self.color
+                    .mix(self.color_focus, self.focus)
+                    .mix(self.color_active, self.active)
+                    .mix(self.color_hover, self.hover)
+                    .mix(self.color_down, self.down)
+                    .mix(self.color_disabled, self.disabled)
+
+                let color_stroke = self.border_color
+                    .mix(self.border_color_focus, self.focus)
+                    .mix(self.border_color_active, self.active)
+                    .mix(self.border_color_hover, self.hover)
+                    .mix(self.border_color_down, self.down)
+                    .mix(self.border_color_disabled, self.disabled)
+
+                sdf.fill_keep(color_fill)
+                sdf.stroke(color_stroke, self.border_size)
+
+                // Draw mark (inner dot)
+                sdf.circle(center_px.x, center_px.y + self.mark_offset, radius_px * 0.5 - self.border_size * 0.75)
+
+                let mark_color = self.mark_color
+                    .mix(self.mark_color_active, self.active)
+                    .mix(self.mark_color_disabled, self.disabled)
+
+                sdf.fill(mark_color)
+
+                // Focus ring (drawn last so it's visible outside the bounds)
+                if self.focus > 0.0 {
+                    sdf.circle(center_px.x, center_px.y, radius_px + 1.0)
+                    sdf.stroke(mix(vec4(0.0, 0.0, 0.0, 0.0), self.border_color_focus, self.focus), 2.0)
+                }
+
+                return sdf.result
+            }
         }
 
         draw_text +: {


### PR DESCRIPTION
💡 What: Added a 2px outer focus ring in the `pixel: fn()` of `ShadRadioItem`.
🎯 Why: `ShadRadioItem` was lacking a distinct, high-contrast outer focus ring when `self.focus > 0.0`, reducing keyboard navigation accessibility.
♿ Accessibility: Improved keyboard focus visibility by matching the high-contrast outline pattern used in `ShadCheckbox` and `ShadToggle`.

---
*PR created automatically by Jules for task [3485004901890960401](https://jules.google.com/task/3485004901890960401) started by @wheregmis*