### PR TITLE
Switch Makepad to web_groundup & tweak CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  MAKEPAD_GIT_BRANCH: dev
+  MAKEPAD_GIT_BRANCH: web_groundup
 
 jobs:
   cargo-check:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout sibling makepad workspace
         shell: bash
-        run: git clone --depth 1 --branch "${MAKEPAD_GIT_BRANCH}" https://github.com/makepad/makepad.git "${GITHUB_WORKSPACE}/../makepad"
+        run: git clone --depth 1 --branch "${MAKEPAD_GIT_BRANCH}" https://github.com/wheregmis/makepad.git "${GITHUB_WORKSPACE}/../makepad"
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
@@ -65,7 +65,7 @@ jobs:
 
       - name: Checkout sibling makepad workspace
         shell: bash
-        run: git clone --depth 1 --branch "${MAKEPAD_GIT_BRANCH}" https://github.com/makepad/makepad.git "${GITHUB_WORKSPACE}/../makepad"
+        run: git clone --depth 1 --branch "${MAKEPAD_GIT_BRANCH}" https://github.com/wheregmis/makepad.git "${GITHUB_WORKSPACE}/../makepad"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAKEPAD_BRANCH: webgpu
+  MAKEPAD_BRANCH: web_groundup
   APP_PACKAGE: makepad-gallery
   WASM_BINDGEN_VERSION: 0.2.114
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/wasm-pages.yml
+++ b/.github/workflows/wasm-pages.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  MAKEPAD_GIT_BRANCH: webgpu
+  MAKEPAD_GIT_BRANCH: web_groundup
   WASM_BINDGEN_VERSION: 0.2.114
 
 jobs:
@@ -64,7 +64,7 @@ jobs:
         run: cargo makepad wasm install-toolchain
 
       - name: Build Wasm package
-        run: ./scripts/build_wasm.sh -p "${APP_PACKAGE}" --no-threads --bindgen
+        run: ./scripts/build_wasm.sh -p "${APP_PACKAGE}" --profile=small --bindgen --no-threads
 
       - name: Patch index.html for GitHub Pages subpath hosting
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "aho-corasick"
@@ -55,7 +55,7 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "bitflags"
@@ -66,12 +66,12 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "cfg-if"
@@ -140,7 +140,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "byteorder",
 ]
@@ -234,7 +234,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -242,12 +242,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-widgets",
 ]
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -280,7 +280,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -325,17 +325,17 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-gallery"
@@ -350,7 +350,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-live-id",
 ]
@@ -371,7 +371,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "ttf-parser",
 ]
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -403,7 +403,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -411,12 +411,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -447,12 +447,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "ash",
  "bitflags 2.10.0",
@@ -476,7 +476,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/wheregmis/makepad.git?branch=webgpu)",
+ "smallvec 1.15.1 (git+https://github.com/wheregmis/makepad.git?branch=web_groundup)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -488,7 +488,7 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-router"
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -532,13 +532,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/wheregmis/makepad.git?branch=webgpu)",
+ "smallvec 1.15.1 (git+https://github.com/wheregmis/makepad.git?branch=web_groundup)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -555,12 +555,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "bitflags 2.10.0",
  "makepad-error-log",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -599,7 +599,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -621,12 +621,12 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "simd-adler32",
 ]
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -642,7 +642,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -651,7 +651,7 @@ dependencies = [
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "memchr"
@@ -774,7 +774,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "bitflags 2.10.0",
  "memchr 2.7.6",
@@ -844,12 +844,12 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/wheregmis/makepad.git?branch=webgpu)",
+ "smallvec 1.15.1 (git+https://github.com/wheregmis/makepad.git?branch=web_groundup)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -866,12 +866,12 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "smallvec"
@@ -882,7 +882,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "spirv"
@@ -927,27 +927,27 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-ident"
@@ -958,22 +958,22 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "unicode-segmentation"
@@ -990,7 +990,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -1012,7 +1012,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "bitflags 2.11.1",
  "wayland-backend",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "log",
  "pkg-config",
@@ -1040,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "windows-collections",
  "windows-core",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "windows-core",
 ]
@@ -1058,9 +1058,9 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
- "windows-link 0.2.1 (git+https://github.com/wheregmis/makepad.git?branch=webgpu)",
+ "windows-link 0.2.1 (git+https://github.com/wheregmis/makepad.git?branch=web_groundup)",
  "windows-result",
  "windows-strings",
 ]
@@ -1068,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
  "windows-core",
 ]
@@ -1082,22 +1082,22 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
- "windows-link 0.2.1 (git+https://github.com/wheregmis/makepad.git?branch=webgpu)",
+ "windows-link 0.2.1 (git+https://github.com/wheregmis/makepad.git?branch=web_groundup)",
 ]
 
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/wheregmis/makepad.git?branch=webgpu#9cf96bc9b983593ab21841ad901c07d43c7716c1"
+source = "git+https://github.com/wheregmis/makepad.git?branch=web_groundup#93e1667470cd1d7064fc40ed45d75a2393a90362"
 dependencies = [
- "windows-link 0.2.1 (git+https://github.com/wheregmis/makepad.git?branch=webgpu)",
+ "windows-link 0.2.1 (git+https://github.com/wheregmis/makepad.git?branch=web_groundup)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = [
 resolver = "3"
 
 [workspace.dependencies]
-makepad-live-id = { git = "https://github.com/wheregmis/makepad.git", branch = "webgpu", version = "1.0.0" }
-makepad-micro-serde = { git = "https://github.com/wheregmis/makepad.git", branch = "webgpu", version = "1.0.0" }
-makepad-draw = { git = "https://github.com/wheregmis/makepad.git", branch = "webgpu", version = "2.0.0" }
-makepad-widgets = { git = "https://github.com/wheregmis/makepad.git", branch = "webgpu", version = "2.0.0" }
-makepad-code-editor = { git = "https://github.com/wheregmis/makepad.git", branch = "webgpu", version = "2.0.0" }
+makepad-live-id = { git = "https://github.com/wheregmis/makepad.git", branch = "web_groundup", version = "1.0.0" }
+makepad-micro-serde = { git = "https://github.com/wheregmis/makepad.git", branch = "web_groundup", version = "1.0.0" }
+makepad-draw = { git = "https://github.com/wheregmis/makepad.git", branch = "web_groundup", version = "2.0.0" }
+makepad-widgets = { git = "https://github.com/wheregmis/makepad.git", branch = "web_groundup", version = "2.0.0" }
+makepad-code-editor = { git = "https://github.com/wheregmis/makepad.git", branch = "web_groundup", version = "2.0.0" }
 makepad-components = { path = "makepad-components", version = "1.0.0" }
 makepad-icon = { path = "makepad-icon", version = "1.0.0" }
 makepad-router = { path = "makepad_router", version = "1.0.0" }

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
-run:
-	cargo run
+run_wasm_no_threads:
+	cargo makepad wasm run -p makepad-gallery --release --no-threads
 
 run_wasm:
-	cargo makepad wasm run -p makepad-gallery --bindgen --release --no-threads
+	cargo makepad wasm run -p makepad-gallery --release
 
 build_wasm:
-	./scripts/build_wasm.sh -p makepad-gallery --profile=small --bindgen --no-threads
+	./scripts/build_wasm.sh -p makepad-gallery --profile=small --no-threads

--- a/makepad-components/src/radio_group.rs
+++ b/makepad-components/src/radio_group.rs
@@ -22,7 +22,6 @@ script_mod! {
     mod.widgets.ShadRadioItem = RadioButtonFlat{
         width: Fit
         height: Fit
-        grab_key_focus: true
         padding: Inset{left: 0, right: 0, top: 0, bottom: 0}
         label_walk +: {
             margin: theme.mspace_h_1{left: 18.0}

--- a/makepad-components/src/slider.rs
+++ b/makepad-components/src/slider.rs
@@ -8,7 +8,6 @@ script_mod! {
         width: Fill
         height: 16
         margin: Inset{}
-        grab_key_focus: true
         default: 0.5
         min: 0.0
         max: 1.0

--- a/makepad-components/src/switch.rs
+++ b/makepad-components/src/switch.rs
@@ -6,7 +6,6 @@ script_mod! {
 
     // Single switch/toggle component: themed Toggle (same as gallery uses)
     mod.widgets.ShadSwitch = Toggle{
-        grab_key_focus: true
         draw_text.color: (shad_theme.color_primary)
         draw_text.text_style.font_size: 10
 


### PR DESCRIPTION
Point CI and workspace dependencies to the makepad web_groundup branch (using the wheregmis fork in CI checkouts). Update preview/wasm workflows to use the new branch and adjust the wasm build to use --profile=small (and --bindgen/--no-threads ordering). Update Cargo.toml workspace deps to web_groundup so the project uses that branch; Cargo.lock updated accordingly.