### PR TITLE
⚡ Bolt: Avoid `.cloned()` on `Copy` types in nested routing loop

### DIFF
--- a/makepad_router/crates/makepad-router-widgets/src/widget/nested.rs
+++ b/makepad_router/crates/makepad-router-widgets/src/widget/nested.rs
@@ -26,8 +26,8 @@ impl RouterWidget {
             .routes
             .patterns
             .keys()
-            .cloned()
-            .chain(self.child_routers.keys().cloned())
+            .copied()
+            .chain(self.child_routers.keys().copied())
         {
             let Some(pattern_obj) = self.router.route_registry.get_pattern(route_id) else {
                 continue;


### PR DESCRIPTION
💡 What: Replaced `.cloned()` with `.copied()` when iterating over `LiveId` keys in the nested routing hot loop (`makepad_router/crates/makepad-router-widgets/src/widget/nested.rs`).
🎯 Why: `LiveId` is a small `Copy` type (a `u64` wrapper). Calling `.cloned()` on it is less idiomatic in Rust and can misleadingly imply that allocations or heavier copies are happening. `.copied()` clearly signals the intent and is technically optimal.
📊 Impact: Minor optimization and stylistic cleanup in a routing hot loop.
🔬 Measurement: Verified using standard `cargo clippy` which often flags this pattern.
🧪 Verification: `cargo test -p makepad-router-widgets --locked` passed successfully.

---
*PR created automatically by Jules for task [4344928762747838441](https://jules.google.com/task/4344928762747838441) started by @wheregmis*