### PR TITLE
🎨 Palette: Add keyboard focus to form controls

### DIFF
--- a/makepad-components/src/radio_group.rs
+++ b/makepad-components/src/radio_group.rs
@@ -20,6 +20,7 @@ script_mod! {
     }
 
     mod.widgets.ShadRadioItem = RadioButtonFlat{
+        grab_key_focus: true
         width: Fit
         height: Fit
         padding: Inset{left: 0, right: 0, top: 0, bottom: 0}

--- a/makepad-components/src/slider.rs
+++ b/makepad-components/src/slider.rs
@@ -5,6 +5,7 @@ script_mod! {
     use mod.widgets.*
 
     mod.widgets.ShadSlider = mod.widgets.SliderRoundFlat{
+        grab_key_focus: true
         width: Fill
         height: 16
         margin: Inset{}

--- a/makepad-components/src/switch.rs
+++ b/makepad-components/src/switch.rs
@@ -6,6 +6,7 @@ script_mod! {
 
     // Single switch/toggle component: themed Toggle (same as gallery uses)
     mod.widgets.ShadSwitch = Toggle{
+        grab_key_focus: true
         draw_text.color: (shad_theme.color_primary)
         draw_text.text_style.font_size: 10
 


### PR DESCRIPTION
💡 What: Added `grab_key_focus: true` to `ShadSwitch`, `ShadRadioItem`, and `ShadSlider` components.
🎯 Why: Without this property, keyboard users cannot focus, interact with, or tab to these standard form controls, breaking accessibility.
📸 Before/After: Visuals are unchanged (focus styling was already present, just unreachable).
♻️ Accessibility: Improves keyboard navigation by ensuring these interactive elements are part of the standard tab order.

---
*PR created automatically by Jules for task [8472809765027752855](https://jules.google.com/task/8472809765027752855) started by @wheregmis*