### PR TITLE
🎨 Palette: Make tabs keyboard reachable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,6 @@
 ## $(date +%Y-%m-%d) – Focus Ring Fallbacks for Form Controls
 **Learning:** Interactive components like Switch, RadioGroup, and Slider need `grab_key_focus: true` and an explicit `border_color_focus` (usually mapping to `color_primary`) to provide visual feedback for keyboard users. Without these properties, the components are untabbable or offer zero visual indication when focused.
 **Action:** Always verify `grab_key_focus` and explicit `focus` state styles (often using `border_color_focus` or drawing boxes mapped to `self.focus`) when building or reviewing interactive controls.
+## $(date +%Y-%m-%d) – Make tabs reachable via keyboard
+**Learning:** In the Makepad components library, interactive elements like tab triggers can be excluded from keyboard navigation if `grab_key_focus: true` is not explicitly set in their DSL definition. This renders `ShadTabsTrigger` inaccessible to keyboard-only users.
+**Action:** When building interactive layout components that inherit from base widgets like `ButtonFlat`, ensure `grab_key_focus: true` is included to maintain tab accessibility.

--- a/makepad-components/src/tabs.rs
+++ b/makepad-components/src/tabs.rs
@@ -38,6 +38,7 @@ script_mod! {
         height: 36
         enable_long_press: true
         reset_hover_on_click: true
+        grab_key_focus: true
         padding: Inset{left: 14, right: 14, top: 0, bottom: 0}
 
         draw_bg +: {


### PR DESCRIPTION
💡 What: Added `grab_key_focus: true` to the `ShadTabsTrigger` component.
🎯 Why: Without this property, tab buttons were inaccessible via the Tab key, preventing keyboard-only users from navigating tabbed interfaces.
📸 Before/After: No visual changes; affects navigation flow.
♿ Accessibility: The `ShadTabsTrigger` control can now receive keyboard focus, ensuring complete keyboard reachability for `ShadTabs` interfaces.

---
*PR created automatically by Jules for task [5784681294787981161](https://jules.google.com/task/5784681294787981161) started by @wheregmis*