### PR TITLE
🎨 Palette: Add keyboard focus to menu triggers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -71,3 +71,6 @@
 ## $(date +%Y-%m-%d) – Make tabs reachable via keyboard
 **Learning:** In the Makepad components library, interactive elements like tab triggers can be excluded from keyboard navigation if `grab_key_focus: true` is not explicitly set in their DSL definition. This renders `ShadTabsTrigger` inaccessible to keyboard-only users.
 **Action:** When building interactive layout components that inherit from base widgets like `ButtonFlat`, ensure `grab_key_focus: true` is included to maintain tab accessibility.
+## 2026-05-10 – Make buttons reachable via keyboard
+**Learning:** In the Makepad components library, interactive elements inheriting from base widgets like `ButtonFlat` can be excluded from keyboard navigation if `grab_key_focus: true` is not explicitly set in their DSL definition.
+**Action:** When building interactive layout components that inherit from base widgets, ensure `grab_key_focus: true` is included to maintain accessibility.

--- a/makepad-components/src/menubar.rs
+++ b/makepad-components/src/menubar.rs
@@ -18,6 +18,7 @@ script_mod! {
     mod.widgets.ShadMenubarTrigger = ButtonFlat{
         height: 30
         enable_long_press: true
+        grab_key_focus: true
         padding: Inset{left: 10, right: 10, top: 0, bottom: 0}
 
         draw_bg +: {

--- a/makepad-components/src/navigation_menu.rs
+++ b/makepad-components/src/navigation_menu.rs
@@ -30,6 +30,7 @@ script_mod! {
     mod.widgets.ShadNavigationMenuTrigger = ButtonFlat{
         height: 36
         enable_long_press: true
+        grab_key_focus: true
         padding: Inset{left: 14, right: 14, top: 0, bottom: 0}
 
         draw_bg +: {


### PR DESCRIPTION
💡 What: Added `grab_key_focus: true` to `ShadNavigationMenuTrigger` and `ShadMenubarTrigger`.
🎯 Why: These interactive triggers inherited from `ButtonFlat` but were excluded from tab keyboard navigation.
♿ Accessibility: Ensures that main navigation surfaces and menubar controls are fully keyboard reachable.

---
*PR created automatically by Jules for task [7445747406362827467](https://jules.google.com/task/7445747406362827467) started by @wheregmis*