### PR TITLE
⚡ Bolt: Eliminate redundant string allocations in command palette fallback search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-05-08 – Eliminating Redundant Route Cloning in Makepad Router Action Dispatch
 **Learning:** In the Makepad router widgets library (`makepad-router-widgets`), `queue_route_actions` previously accepted a full `&Route` reference to extract the ID, while callers simultaneously created `RouterAction` enum variants (like `Navigate`, `Replace`, `Reset`) by calling `.clone()` on the `Route`. Because `Route` contains nested objects (like `String` identifiers and `HashMap` query parameters), this `.clone()` caused significant heap allocation and churn during every route transition.
 **Action:** By modifying `queue_route_actions` to strictly accept `new_route_id: LiveId` (a lightweight `Copy` type), callers can extract the `LiveId` upfront, dispatch lifecycle events using `&Route`, and finally *move* ownership of the original `Route` into the `RouterAction` enum variant. This safely and idiomatically eliminates the `.clone()`, reducing memory allocations in the hot path.
+
+## 2025-05-11 - Zero-allocation case-insensitive substring search
+**Learning:** Calling `to_ascii_lowercase()` in a loop for case-insensitive `contains` checks (like `command.title.to_ascii_lowercase().contains(&query)`) forces heap allocations per iteration per string.
+**Action:** Use `.as_bytes().windows(needle.len()).any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))` to perform a zero-allocation case-insensitive substring search.

--- a/makepad-gallery/src/ui/command_palette.rs
+++ b/makepad-gallery/src/ui/command_palette.rs
@@ -38,6 +38,20 @@ fn matches_command_query(term: &CommandSearchTerm, query: &str) -> bool {
         || term.shortcut.contains(query)
 }
 
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let needle_len = needle.len();
+    if haystack.len() < needle_len {
+        return false;
+    }
+    haystack
+        .as_bytes()
+        .windows(needle_len)
+        .any(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
 fn command_results_summary(query: &str, matches_count: usize) -> String {
     let query = query.trim();
     let total = catalog::entries().len();
@@ -496,15 +510,18 @@ impl GalleryCommandPalette {
         }
 
         // Fallback for any trailing entries not in cache
+        // Optimization: avoid 3 heap allocations from `.to_ascii_lowercase()` in the fallback search loop.
+        // Previously: called `.to_ascii_lowercase()` on title, section, and shortcut, which allocated three Strings per iteration.
+        // Now: we use a zero-allocation `contains_ignore_ascii_case` helper.
         for (index, command) in catalog::entries()
             .iter()
             .enumerate()
             .skip(search_terms.len())
         {
             if query.is_empty()
-                || command.title.to_ascii_lowercase().contains(&query)
-                || command.section.to_ascii_lowercase().contains(&query)
-                || command.shortcut.to_ascii_lowercase().contains(&query)
+                || contains_ignore_ascii_case(&command.title, &query)
+                || contains_ignore_ascii_case(&command.section, &query)
+                || contains_ignore_ascii_case(&command.shortcut, &query)
             {
                 self.filtered_indices_scratch.push(index);
             }


### PR DESCRIPTION
💡 What: Replaced `.to_ascii_lowercase().contains()` with a custom `contains_ignore_ascii_case` helper.
🎯 Why: Calling `.to_ascii_lowercase()` inside the command palette fallback loop resulted in 3 heap-allocated Strings per iteration, hurting search responsiveness.
📊 Impact: Completely eliminates heap allocations for case-insensitive substring matching during fallback searches.
🔬 Measurement: Code inspection reveals zero `String` or `Vec` allocations in the new matching helper.
🧪 Verification: `cargo clippy`, `cargo fmt`, and `cargo test --workspace` run and passing.

---
*PR created automatically by Jules for task [18335115799475614618](https://jules.google.com/task/18335115799475614618) started by @wheregmis*