### PR TITLE
🎨 Palette: Make Shadcn buttons reachable via keyboard

### DIFF
--- a/makepad-components/src/button.rs
+++ b/makepad-components/src/button.rs
@@ -248,6 +248,7 @@ script_mod! {
     mod.widgets.ShadButtonBase = mod.widgets.ButtonFlat{
         height: (shad_theme.control_height_md)
         enable_long_press: true
+        grab_key_focus: true
         padding: Inset{
             left: (shad_theme.control_padding_x_md),
             right: (shad_theme.control_padding_x_md),
@@ -362,6 +363,7 @@ script_mod! {
     mod.widgets.ShadButtonLink = mod.widgets.ButtonFlat{
         height: 36
         enable_long_press: true
+        grab_key_focus: true
         padding: Inset{left: 4, right: 4, top: 0, bottom: 0}
         draw_bg +: {
             color: #0000
@@ -414,6 +416,7 @@ script_mod! {
         width: 36
         height: 36
         enable_long_press: true
+        grab_key_focus: true
         spacing: 0.0
         padding: Inset{left: 0, right: 0, top: 0, bottom: 0}
         draw_bg +: {


### PR DESCRIPTION
💡 What: Added `grab_key_focus: true` to `ShadButtonBase`, `ShadButtonLink`, and `ShadButtonIconOutline` in `makepad-components/src/button.rs`.
🎯 Why: Makepad widgets that inherit from `ButtonFlat` (or `ButtonFlatIcon`) do not automatically receive keyboard focus. This change ensures that all Shadcn-styled buttons throughout the application are reachable via keyboard navigation (Tab key).
♿ Accessibility: Improved keyboard accessibility for buttons, allowing screen reader and keyboard-only users to properly interact with the UI.

---
*PR created automatically by Jules for task [6130488954603162457](https://jules.google.com/task/6130488954603162457) started by @wheregmis*