### PR TITLE
🎨 Palette: Make ShadButtonBase and ShadButtonIconOutline keyboard focusable

### DIFF
--- a/makepad-components/src/button.rs
+++ b/makepad-components/src/button.rs
@@ -246,6 +246,7 @@ script_mod! {
     }
 
     mod.widgets.ShadButtonBase = mod.widgets.ButtonFlat{
+        grab_key_focus: true
         height: (shad_theme.control_height_md)
         enable_long_press: true
         padding: Inset{
@@ -411,6 +412,7 @@ script_mod! {
     }
 
     mod.widgets.ShadButtonIconOutline = mod.widgets.ButtonFlatIcon{
+        grab_key_focus: true
         width: 36
         height: 36
         enable_long_press: true


### PR DESCRIPTION
💡 What: Added `grab_key_focus: true` to `ShadButtonBase` and `ShadButtonIconOutline` base components.
🎯 Why: Interactive components that inherit from base widgets like `ButtonFlat` don't receive keyboard focus automatically unless explicitly set. Adding this property ensures they can be reached via Tab navigation without needing it explicitly added to every inherited instance.
♿ Accessibility: Improved keyboard accessibility for standard buttons and icon buttons across the application.

---
*PR created automatically by Jules for task [10715474547569079470](https://jules.google.com/task/10715474547569079470) started by @wheregmis*