### PR TITLE
🎨 Palette: Add aria_label to gallery mobile sidebar menu buttons

### DIFF
--- a/makepad-gallery/src/ui/sidebar.rs
+++ b/makepad-gallery/src/ui/sidebar.rs
@@ -84,6 +84,7 @@ macro_rules! define_gallery_sidebar {
             }
 
             mod.widgets.GalleryMobileSidebarMenuButton = mod.widgets.GalleryMobileSidebarIconButton{
+                button = { aria_label: "Open menu" }
                 icon := IconMenu{
                     width: 18
                     height: 18
@@ -93,6 +94,7 @@ macro_rules! define_gallery_sidebar {
             }
 
             mod.widgets.GalleryMobileSidebarCloseButton = mod.widgets.GalleryMobileSidebarIconButton{
+                button = { aria_label: "Close menu" }
                 icon := IconX{
                     width: 16
                     height: 16


### PR DESCRIPTION
💡 What: Added `aria_label` properties to the `GalleryMobileSidebarMenuButton` and `GalleryMobileSidebarCloseButton` widgets in `makepad-gallery/src/ui/sidebar.rs`.
🎯 Why: These buttons are icon-only (using `IconMenu` and `IconX`) and lacked accessible names, making them difficult to understand for users relying on screen readers.
♿ Accessibility: Improves screen reader compatibility by explicitly defining the buttons' purposes ("Open menu" and "Close menu").

---
*PR created automatically by Jules for task [2310235946277369506](https://jules.google.com/task/2310235946277369506) started by @wheregmis*