### PR TITLE
⚡ Bolt: Optimize String allocations in route registry HashMap indexing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-05-11 - Zero-allocation case-insensitive substring search
 **Learning:** Calling `to_ascii_lowercase()` in a loop for case-insensitive `contains` checks (like `command.title.to_ascii_lowercase().contains(&query)`) forces heap allocations per iteration per string.
 **Action:** Use `.as_bytes().windows(needle.len()).any(|w| w.eq_ignore_ascii_case(needle.as_bytes()))` to perform a zero-allocation case-insensitive substring search.
+
+## $(date +%Y-%m-%d) - Avoiding Unnecessary Allocations during HashMap Insertions
+**Learning:** Using `HashMap::entry(key.clone()).or_insert(...)` or `.or_default()` allocates a `String` unconditionally. This creates significant heap churn on a hot path if the keys frequently already exist in the map (e.g., when indexing shared paths in `RouteRegistry`).
+**Action:** Use a check-then-insert approach, looking up with a borrowed slice (`contains_key` or `get_mut`), and only calling `clone()` to allocate the owned `String` when an insertion actually needs to happen.

--- a/makepad_router/crates/makepad-router-core/src/registry.rs
+++ b/makepad_router/crates/makepad-router-core/src/registry.rs
@@ -324,18 +324,26 @@ impl RouteRegistry {
             return;
         };
 
+        // Optimization: avoid redundant String allocations when building hash map indices.
+        // Previously: called `HashMap::entry(key.clone())`, which allocated a String on the heap
+        //             even if the key already existed. This was particularly wasteful for
+        //             `by_first_segment` where many routes share the same first segment.
+        // Now: we check for existence with `contains_key` using a borrowed string slice
+        //      before cloning and inserting.
         if let Some(path) = meta.exact_static_path.as_ref() {
-            self.exact_static
-                .entry(path.clone())
-                .or_insert(entry.route_id);
+            if !self.exact_static.contains_key(path) {
+                self.exact_static.insert(path.clone(), entry.route_id);
+            }
         }
 
         match meta.first_static_segment.as_ref() {
-            Some(first) => self
-                .by_first_segment
-                .entry(first.clone())
-                .or_default()
-                .push(idx),
+            Some(first) => {
+                if let Some(vec) = self.by_first_segment.get_mut(first) {
+                    vec.push(idx);
+                } else {
+                    self.by_first_segment.insert(first.clone(), vec![idx]);
+                }
+            }
             None if meta.has_wildcard => self.fallback_wildcard.push(idx),
             None => self.fallback_dynamic.push(idx),
         }
@@ -355,16 +363,18 @@ impl RouteRegistry {
                 continue;
             };
             if let Some(path) = meta.exact_static_path.as_ref() {
-                self.exact_static
-                    .entry(path.clone())
-                    .or_insert(entry.route_id);
+                if !self.exact_static.contains_key(path) {
+                    self.exact_static.insert(path.clone(), entry.route_id);
+                }
             }
             match meta.first_static_segment.as_ref() {
-                Some(first) => self
-                    .by_first_segment
-                    .entry(first.clone())
-                    .or_default()
-                    .push(idx),
+                Some(first) => {
+                    if let Some(vec) = self.by_first_segment.get_mut(first) {
+                        vec.push(idx);
+                    } else {
+                        self.by_first_segment.insert(first.clone(), vec![idx]);
+                    }
+                }
                 None if meta.has_wildcard => self.fallback_wildcard.push(idx),
                 None => self.fallback_dynamic.push(idx),
             }


### PR DESCRIPTION
💡 What: Avoids calling `.clone()` unconditionally when inserting into `HashMap`s in `RouteRegistry`.
🎯 Why: `HashMap::entry(key.clone()).or_default()` forces a `String` allocation even if the key already exists. In `by_first_segment`, many nested routes share the same first static segment (e.g., `/user/:id` and `/user/settings`), leading to unnecessary heap churn during initialization or live reloading.
📊 Impact: Eliminates heap allocations for `String` cloning when indexing routes that share static prefixes.
🔬 Measurement: Code analysis confirms that `contains_key` and `get_mut` operate on the borrowed slice, bypassing allocation on the existing-key code path.
🧪 Verification: Unit tests in `makepad-router-core` run via `cargo test` pass successfully.

---
*PR created automatically by Jules for task [4429927407947260880](https://jules.google.com/task/4429927407947260880) started by @wheregmis*